### PR TITLE
Allow disabling NSQ service reloading

### DIFF
--- a/manifests/nsqadmin.pp
+++ b/manifests/nsqadmin.pp
@@ -12,6 +12,9 @@
 # * `service_ensure`
 #   Ensure nsqadmin service is running
 #
+# * `service_reload`
+#   Automatically restart the service when config changes
+#
 # * `http_address`
 #   The IP and port nsqadmin will bind to.  e.g. 0.0.0.0:4171
 #
@@ -27,6 +30,7 @@
 class nsq::nsqadmin(
   Boolean $service_manage                 = $::nsq::params::service_manage,
   Variant[Boolean, Undef] $service_ensure = $::nsq::params::service_ensure,
+  Boolean $service_reload                 = $::nsq::params::service_reload,
   String $http_address                    = '0.0.0.0:4171',
   Array $nsqlookupd_addresses             = [ '127.0.0.1:4161' ],
   String $statsd_prefix                   = $::nsq::params::statsd_prefix,

--- a/manifests/nsqadmin/config.pp
+++ b/manifests/nsqadmin/config.pp
@@ -5,7 +5,7 @@
 #
 class nsq::nsqadmin::config {
 
-  $notify_service = $nsq::nsqadmin::service_manage ? {
+  $notify_service = ($nsq::nsqadmin::service_manage and $nsq::nsqadmin::service_reload) ? {
     true    => Service['nsqadmin'],
     false   => undef,
     default => undef,

--- a/manifests/nsqd.pp
+++ b/manifests/nsqd.pp
@@ -12,6 +12,9 @@
 # * `service_ensure`
 #   Ensure nsqd service is running
 #
+# * `service_reload`
+#   Automatically restart the service when config changes
+#
 # * `verbose_logging`
 #   Toggle verbose logging
 #
@@ -44,6 +47,7 @@
 class nsq::nsqd(
   Boolean $service_manage                     = $::nsq::params::service_manage,
   Variant[Boolean, Undef] $service_ensure     = $::nsq::params::service_ensure,
+  Boolean $service_reload                     = $::nsq::params::service_reload,
   Boolean $verbose_logging                    = false,
   String  $log_level                          = $::nsq::params::log_level,
   String  $tcp_address                        = '0.0.0.0:4150',

--- a/manifests/nsqd/config.pp
+++ b/manifests/nsqd/config.pp
@@ -5,7 +5,7 @@
 #
 class nsq::nsqd::config {
 
-  $notify_service = $nsq::nsqd::service_manage ? {
+  $notify_service = ($nsq::nsqd::service_manage and $nsq::nsqd::service_reload) ? {
     true    => Service['nsqd'],
     false   => undef,
     default => undef,

--- a/manifests/nsqlookupd.pp
+++ b/manifests/nsqlookupd.pp
@@ -12,6 +12,9 @@
 # * `service_ensure`
 #   Ensure nsqd service is running
 #
+# * `service_reload`
+#   Automatically restart the service when config changes
+#
 # * `verbose_logging`
 #   Toggle verbose logging
 #
@@ -30,6 +33,7 @@
 class nsq::nsqlookupd(
   Boolean $service_manage                 = $::nsq::params::service_manage,
   Variant[Boolean, Undef] $service_ensure = $::nsq::params::service_ensure,
+  Boolean $service_reload                 = $::nsq::params::service_reload,
   Boolean $verbose_logging                = false,
   String $log_level                       = $::nsq::params::log_level,
   String $tcp_address                     = '0.0.0.0:4160',
@@ -56,4 +60,3 @@ class nsq::nsqlookupd(
     }
   }
 }
-

--- a/manifests/nsqlookupd/config.pp
+++ b/manifests/nsqlookupd/config.pp
@@ -5,7 +5,7 @@
 #
 class nsq::nsqlookupd::config {
 
-  $notify_service = $nsq::nsqlookupd::service_manage ? {
+  $notify_service = $nsq::nsqlookupd::service_manage and $nsq::nsqlookupd::service_reload ? {
     true    => Service['nsqlookupd'],
     false   => undef,
     default => undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,8 @@ class nsq::params {
 
   $service_ensure = undef
 
+  $service_reload = true
+
   $statsd_address = '127.0.0.1:8125'
 
   $statsd_prefix = 'nsq.%s'


### PR DESCRIPTION
Add parameters to configure whether Puppet will reload a daemon when
its configuration has changed.

Originally approved in https://github.com/monzo/puppet/pull/284