### PR TITLE
Fix nsqlookupd::config syntax

### DIFF
--- a/manifests/nsqlookupd/config.pp
+++ b/manifests/nsqlookupd/config.pp
@@ -5,7 +5,7 @@
 #
 class nsq::nsqlookupd::config {
 
-  $notify_service = $nsq::nsqlookupd::service_manage and $nsq::nsqlookupd::service_reload ? {
+  $notify_service = ($nsq::nsqlookupd::service_manage and $nsq::nsqlookupd::service_reload) ? {
     true    => Service['nsqlookupd'],
     false   => undef,
     default => undef,


### PR DESCRIPTION
This prevents Puppet trying to treat `$nsq::nsqlookupd::service_reload` as a class name