### PR TITLE
Add config setting for nsqd open file limit

### DIFF
--- a/manifests/nsqd.pp
+++ b/manifests/nsqd.pp
@@ -59,6 +59,7 @@ class nsq::nsqd(
   String  $msg_timeout                        = $::nsq::params::msg_timeout,
   String  $broadcast_address                  = $::networking['hostname'],
   String  $e2e_processing_latency_percentiles = "1.0, 0.99, 0.95",
+  Integer $limit_nofile                       = 65536,
 ){
   include nsq::nsqd::config
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,4 +31,6 @@ class nsq::params {
   $msg_timeout = '60s'
 
   $log_level = 'info'
+
+  $limit_nofile = 65536
 }

--- a/templates/nsqd.service.erb
+++ b/templates/nsqd.service.erb
@@ -6,7 +6,7 @@ After=network.target
 ExecStart=/bin/sh -c '<%= scope.lookupvar('nsq::bin_dir')%>/bin/nsqd -config <%= scope.lookupvar('nsq::conf_dir') %>/nsqd.conf'
 Type=simple
 PIDFile=/var/run/nsqd.pid
-LimitNOFILE=65536
+LimitNOFILE=<%= scope.lookupvar('nsq::nsqd::limit_nofile')%>
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
The open file limit was previously hard-coded in the systemd unit file
to 65536. We need to extend this, so we add a new parameter to the nsqd
class.

